### PR TITLE
fix: 🐛 episodes not appearing when expanding a season

### DIFF
--- a/src/components/list/show/Season.tsx
+++ b/src/components/list/show/Season.tsx
@@ -82,7 +82,7 @@ export const Season = ({
           </div>
         </div>
       </div>
-      <div className={`collapse-content ${showChildren ? 'mt-5' : ''} p-0`}>
+      <div className={`${showChildren ? 'mt-5' : ''} p-0`}>
         {showChildren &&
           season.episodes.map((episode) => (
             <Episode


### PR DESCRIPTION
This was due to the collapse-content class on the episodes container

✅ Closes: BUC-80