### PR TITLE
fix: 🐛 page refreshing when not modified

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@trpc/next": "^10.43.1",
     "@trpc/react-query": "^10.43.1",
     "@trpc/server": "^10.43.1",
+    "@vercel/speed-insights": "^1.0.1",
     "daisyui": "^3.9.4",
     "date-fns": "^2.30.0",
     "dice-coefficient": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   '@trpc/server':
     specifier: ^10.43.1
     version: 10.43.1
+  '@vercel/speed-insights':
+    specifier: ^1.0.1
+    version: 1.0.1
   daisyui:
     specifier: ^3.9.4
     version: 3.9.4
@@ -1277,6 +1280,11 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
+
+  /@vercel/speed-insights@1.0.1:
+    resolution: {integrity: sha512-cm8KTTsDgS1AbWsgIEZuMoyPUjclzeqJihyLp0tnA21B/x9iTE8hu2S5zM+/DBzihuHxWL1dx9pCWk22ctMFWQ==}
+    requiresBuild: true
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.11.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}

--- a/src/components/dropdown/CustomDropdown.tsx
+++ b/src/components/dropdown/CustomDropdown.tsx
@@ -25,7 +25,7 @@ export const CustomDropdown = ({
       {label}
     </label>
     <ul
-      className="dropdown-content menu rounded-box mt-4 bg-base-100 p-2 font-semibold"
+      className="menu dropdown-content rounded-box mt-4 bg-base-100 p-2 font-semibold"
       tabIndex={0}
     >
       {items.map((item, index) => (

--- a/src/components/dropdown/DropdownHeader.tsx
+++ b/src/components/dropdown/DropdownHeader.tsx
@@ -17,7 +17,7 @@ export const DropdownHeader = ({
     </label>
     <ul
       tabIndex={0}
-      className="dropdown-content menu rounded-box z-50 w-56 items-start bg-base-100 p-2 shadow"
+      className="menu dropdown-content rounded-box z-50 w-56 items-start bg-base-100 p-2 shadow"
     >
       {children}
     </ul>

--- a/src/components/form/TextArea.tsx
+++ b/src/components/form/TextArea.tsx
@@ -21,7 +21,7 @@ export const TextArea = ({
       </label>
       <textarea
         placeholder={placeholder}
-        className={`input-bordered input h-40 w-full max-w-xs resize-none p-3 ${
+        className={`input input-bordered h-40 w-full max-w-xs resize-none p-3 ${
           error ? 'input-error' : ''
         }`}
         {...props}

--- a/src/components/form/TextInput.tsx
+++ b/src/components/form/TextInput.tsx
@@ -33,7 +33,7 @@ export const TextInput = ({
       <input
         type="text"
         placeholder={placeholder}
-        className={`input-bordered input w-full ${error ? 'input-error' : ''} ${
+        className={`input input-bordered w-full ${error ? 'input-error' : ''} ${
           inputClassName ?? ''
         }`}
         defaultValue={defaultValue}

--- a/src/components/modals/ModalHeader.tsx
+++ b/src/components/modals/ModalHeader.tsx
@@ -21,7 +21,7 @@ export const ModalHeader = ({
         ref={ref}
       >
         <label
-          className="btn-neutral btn btn-circle btn-sm absolute right-2 top-2"
+          className="btn btn-circle btn-neutral btn-sm absolute right-2 top-2"
           onClick={() => void modal.remove()}
         >
           ✕

--- a/src/components/movie/PosterImage.tsx
+++ b/src/components/movie/PosterImage.tsx
@@ -22,7 +22,7 @@ export const PosterImage = ({
   if (url)
     return (
       <Image
-        src={`https://image.tmdb.org/t/p/w500${url}`}
+        src={`https://image.tmdb.org/t/p/w92${url}`}
         alt={alt}
         width={width}
         height={height}

--- a/src/components/nav/Navbar.tsx
+++ b/src/components/nav/Navbar.tsx
@@ -5,7 +5,7 @@ export const Navbar = () => {
   const { isSignedIn, user } = useUser();
 
   return (
-    <nav className="z-60 navbar sticky top-0 bg-base-100">
+    <nav className="navbar sticky top-0 z-60 bg-base-100">
       {isSignedIn ? (
         <>
           <NavbarLink href="/lists" name="BucketList" />

--- a/src/components/nav/NavbarLink.tsx
+++ b/src/components/nav/NavbarLink.tsx
@@ -7,7 +7,7 @@ interface NavbarLinkProps {
 
 export const NavbarLink = ({ href, name }: NavbarLinkProps) => (
   <div className="flex-1">
-    <Link href={href} className="btn-ghost btn text-xl normal-case">
+    <Link href={href} className="btn btn-ghost text-xl normal-case">
       {name}
     </Link>
   </div>

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { z } from "zod";
-import { createEnv } from "@t3-oss/env-nextjs";
+import {z} from 'zod';
+import {createEnv} from '@t3-oss/env-nextjs';
 
 export const env = createEnv({
     /**
@@ -9,7 +9,7 @@ export const env = createEnv({
      */
     server: {
         DATABASE_URL: z.string().url(),
-        NODE_ENV: z.enum(["development", "test", "production"]),
+        NODE_ENV: z.enum(['development', 'test', 'production']),
         DISCORD_CLIENT_ID: z.string(),
         DISCORD_CLIENT_SECRET: z.string(),
         BASE_URL: z.string().url().optional(),
@@ -43,10 +43,13 @@ export const env = createEnv({
         TMDB_API_KEY: process.env.TMDB_API_KEY,
         CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
         WEBHOOK_SECRET: process.env.WEBHOOK_SECRET,
-        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
         NEXT_PUBLIC_CLERK_SIGN_IN_URL: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
-        NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
-        NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
+        NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL:
+        process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
+        NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL:
+        process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
     },
     /**
      * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import { Toaster } from 'react-hot-toast';
 import { dark } from '@clerk/themes';
 import { SentryUserManager } from '~/components/SentryUserManager';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   return (
@@ -20,6 +21,7 @@ const MyApp: AppType = ({ Component, pageProps }) => {
         <Component {...pageProps} />
       </NiceModal.Provider>
       <SentryUserManager />
+      <SpeedInsights />
     </ClerkProvider>
   );
 };

--- a/src/pages/api/webhooks/createUser.ts
+++ b/src/pages/api/webhooks/createUser.ts
@@ -1,11 +1,11 @@
 // Disable the bodyParser so we can access the raw
 // request body for verification.
-import { type NextApiRequest, type NextApiResponse } from 'next';
-import { Webhook, type WebhookRequiredHeaders } from 'svix';
-import { buffer } from 'micro';
-import { type IncomingHttpHeaders } from 'http';
-import { prisma } from '~/server/db';
-import { type WebhookEvent } from '@clerk/clerk-sdk-node';
+import {type NextApiRequest, type NextApiResponse} from 'next';
+import {Webhook, type WebhookRequiredHeaders} from 'svix';
+import {buffer} from 'micro';
+import {type IncomingHttpHeaders} from 'http';
+import {prisma} from '~/server/db';
+import {type WebhookEvent} from '@clerk/clerk-sdk-node';
 
 export const config = {
   api: {

--- a/src/pages/lists/[list].tsx
+++ b/src/pages/lists/[list].tsx
@@ -22,16 +22,6 @@ const List = () => {
   const router = useRouter();
   const { list: listId } = router.query;
 
-  const queryClient = api.useUtils();
-  const previousQueryData = queryClient.lists.getList.getData({
-    id: listId as string,
-  });
-
-  const previousUpdatedAt =
-    previousQueryData?.updatedAt instanceof Date
-      ? previousQueryData.updatedAt.toISOString()
-      : undefined;
-
   const {
     data: list,
     isFetched,
@@ -39,7 +29,6 @@ const List = () => {
   } = api.lists.getList.useQuery(
     {
       id: listId as string,
-      updatedAt: previousUpdatedAt,
     },
     { enabled: !!listId, retry: 3 },
   );
@@ -63,18 +52,6 @@ const List = () => {
         </div>
       </StandardPage>
     );
-
-  // If code is set in the current query data, it means the updatedAt parameter sent to the server is the same as the one in the database.
-  // This means that our local data is the same as the server data, so we can just use set data to the previous query data.
-  if (previousQueryData && 'code' in list) {
-    queryClient.lists.getList.setData(
-      { id: listId as string, updatedAt: previousUpdatedAt },
-      () => {
-        return { ...previousQueryData };
-      },
-    );
-    return;
-  }
 
   if ('code' in list) throw new Error('Data is not a list');
 

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,14 +1,14 @@
 import {
-  authRouter,
-  bucketListRouter,
-  inviteRouter,
-  listsRouter,
-  movieListRouter,
-  searchRouter,
-  showListRouter,
+    authRouter,
+    bucketListRouter,
+    inviteRouter,
+    listsRouter,
+    movieListRouter,
+    searchRouter,
+    showListRouter,
 } from './routers';
-import { createTRPCRouter } from './trpc';
-import { watchedRouter } from '~/server/api/routers/watched';
+import {createTRPCRouter} from './trpc';
+import {watchedRouter} from '~/server/api/routers/watched';
 
 /**
  * This is the primary router for your server.

--- a/src/utils/convertImageToHash.ts
+++ b/src/utils/convertImageToHash.ts
@@ -12,7 +12,7 @@ export const convertImageToHash = async (
   let image;
 
   try {
-    image = await loadImage('https://image.tmdb.org/t/p/w500' + imageId);
+    image = await loadImage('https://image.tmdb.org/t/p/w92' + imageId);
   } catch (error) {
     console.error(error);
     return null;


### PR DESCRIPTION
This was done by moving to the Last-Modified header in favour of custom behaviour, so the browser now does this automatically for us. In addition, migrated to @vercel/speed-insights, and changed the image size of TMDB poster images to 93 instead of 500 to reduce the amount of data the user has to load, only for us to then shrink it wayyyy down.